### PR TITLE
gcp: add environment var and prefix roleset name

### DIFF
--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -1,5 +1,5 @@
 locals {
-  name = "${var.kube_namespace}-${var.kube_sa_name}"
+  name = "${var.environment}-${var.kube_namespace}-${var.kube_sa_name}"
 }
 
 resource "vault_kubernetes_auth_backend_role" "app" {

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -1,3 +1,7 @@
+variable "environment" {
+  type = string
+}
+
 variable "kube_namespace" {
   type = string
 }


### PR DESCRIPTION
The GCP secrets engine for Vault creates one SA per roleset. These SAs
can only be identified using their description (the name is truncated)
which contains the roleset name. For our vault setup where occassionally
we might end up re-building it from scratch, we will end up with orphan
SAs, polluting the project and eventually hitting limits. We want to be
able to identify which environment a vault SA belongs to so that we can
clean them up in scenarios where vault loses its state and "forgets"
about existing SAs.