### PR TITLE
gcp: add read permission for roleset path

### DIFF
--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -13,6 +13,10 @@ resource "vault_kubernetes_auth_backend_role" "app" {
 
 data "vault_policy_document" "app" {
   rule {
+    path         = "${var.gcp_secret_backend}/roleset/${local.name}"
+    capabilities = ["read"]
+  }
+  rule {
     path         = "${var.gcp_secret_backend}/token/${local.name}"
     capabilities = ["create", "read", "update", "delete", "list"]
   }


### PR DESCRIPTION
For the sidecar to adequately masquerade as the GCE metadata endpoint it
needs to be able to serve the project id, the email and the scopes. This
information can be read back from the roleset in vault.